### PR TITLE
Krys/masking csrs

### DIFF
--- a/checks/rvfi_csrc_any_check.sv
+++ b/checks/rvfi_csrc_any_check.sv
@@ -36,8 +36,13 @@ module rvfi_csrc_any_check (
 
 	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rmask = `csrget(`RISCV_FORMAL_CSRC_NAME, rmask);
 	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wmask = `csrget(`RISCV_FORMAL_CSRC_NAME, wmask);
-	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata);
-	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wdata = `csrget(`RISCV_FORMAL_CSRC_NAME, wdata);
+	`ifdef RISCV_FORMAL_CSRC_MASK
+		wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata) & `RISCV_FORMAL_CSRC_MASK;
+		wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wdata = `csrget(`RISCV_FORMAL_CSRC_NAME, wdata) & `RISCV_FORMAL_CSRC_MASK;
+	`else
+		wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata);
+		wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wdata = `csrget(`RISCV_FORMAL_CSRC_NAME, wdata);
+	`endif //RISCV_FORMAL_CSRC_MASK
 
 	wire csr_write = !rvfi.insn[13] || rvfi.insn[19:15];
 	wire csr_read = rvfi.insn[11:7] != 0;
@@ -61,6 +66,9 @@ module rvfi_csrc_any_check (
 			csr_mode_shadow = 0;
 		end else begin
 			if (check) begin
+				`ifdef RISCV_FORMAL_CSRC_MASK
+					assume ((rsval_shadow & `RISCV_FORMAL_CSRC_MASK) == rsval_shadow);
+				`endif
 				if (csr_written && csr_read_valid && csr_insn_addr == `csr_mindex(`RISCV_FORMAL_CSRC_NAME)) begin
 					case (csr_mode_shadow)
 						2'b 00 /* None */,

--- a/checks/rvfi_csrc_const_check.sv
+++ b/checks/rvfi_csrc_const_check.sv
@@ -36,8 +36,12 @@ module rvfi_csrc_const_check (
 
 	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rmask = `csrget(`RISCV_FORMAL_CSRC_NAME, rmask);
 	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wmask = `csrget(`RISCV_FORMAL_CSRC_NAME, wmask);
-	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata);
 	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wdata = `csrget(`RISCV_FORMAL_CSRC_NAME, wdata);
+	`ifdef RISCV_FORMAL_CSRC_MASK
+		wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata) & `RISCV_FORMAL_CSRC_MASK;
+	`else
+		wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata);
+	`endif //RISCV_FORMAL_CSRC_MASK
 
 	wire csr_write = !rvfi.insn[13] || rvfi.insn[19:15];
 	wire csr_read = rvfi.insn[11:7] != 0;

--- a/checks/rvfi_csrc_zero_check.sv
+++ b/checks/rvfi_csrc_zero_check.sv
@@ -36,8 +36,12 @@ module rvfi_csrc_zero_check (
 
 	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rmask = `csrget(`RISCV_FORMAL_CSRC_NAME, rmask);
 	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wmask = `csrget(`RISCV_FORMAL_CSRC_NAME, wmask);
-	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata);
 	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wdata = `csrget(`RISCV_FORMAL_CSRC_NAME, wdata);
+	`ifdef RISCV_FORMAL_CSRC_MASK
+		wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata) & `RISCV_FORMAL_CSRC_MASK;
+	`else
+		wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata);
+	`endif //RISCV_FORMAL_CSRC_MASK
 
 	wire csr_write = !rvfi.insn[13] || rvfi.insn[19:15];
 	wire csr_read = rvfi.insn[11:7] != 0;

--- a/docs/procedure.md
+++ b/docs/procedure.md
@@ -357,6 +357,12 @@ example, `mhpmcounter3 upcnt_hpm=3` declares that the `mhpmcounter3` is controll
 and should be tested with the `csrc_upcnt_check`.  The CSR up-counter check is the only
 check to utilise the hpmevent macro at this time.
 
+Consistency checks can also be appended with `_mask=` with a verilog expression which will be
+applied to the CSR as a bit mask before testing the return value.  Note that `_mask` must be defined
+*after* any other value assignment for the check, but *before* `_hpm`.  For example, the statement
+`misa const=0_mask="32'h 0aaa_ffff"` masks the `misa` CSR and then checks for a constant value of 0.
+A mask value is currently only supported in the `const`, `zero`, and `any` checks.
+
 `const` is currently the only other test to support value assignment.  If no value is provided, a
 value of `rdata_shadow` will be assigned such that any value is accepted provided it is constant.
 


### PR DESCRIPTION
Add support for masking CSRs during checks.  See [procedure doc](docs/procedure.md) for more information.