### PR TITLE
Adding `csrc_hpm` cover check

### DIFF
--- a/checks/rvfi_csrc_hpm_check.sv
+++ b/checks/rvfi_csrc_hpm_check.sv
@@ -1,0 +1,77 @@
+// Copyright (C) 2023  Krystine Dawn Sherwin <krystinedawn@yosyshq.com>
+//
+// Permission to use, copy, modify, and/or distribute this software for any
+// purpose with or without fee is hereby granted, provided that the above
+// copyright notice and this permission notice appear in all copies.
+//
+// THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+// WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+// MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+// ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+// WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+// ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+// OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+module rvfi_csrc_hpm_check (
+	input clock, reset, check,
+	`RVFI_INPUTS
+);
+	// Setup for csrs
+	`RVFI_CHANNEL(rvfi, `RISCV_FORMAL_CHANNEL_IDX)
+
+	localparam [11:0] csr_none = 12'hFFF;
+	`RVFI_INDICES
+
+	`define quoted(txt) txt
+	`define csrget(_name, _type) rvfi.csr_``_name```quoted(_``_type)
+	`define csr_mindex(_name) csr_mindex_``_name
+	`define csr_sindex(_name) csr_sindex_``_name
+	`define csr_uindex(_name) csr_uindex_``_name
+	`define csr_mindexh(_name) csr_mindex_``_name```quoted(h)
+	`define csr_sindexh(_name) csr_sindex_``_name```quoted(h)
+	`define csr_uindexh(_name) csr_uindex_``_name```quoted(h)
+
+	wire csr_insn_valid = rvfi.valid && (rvfi.insn[6:0] == 7'b 1110011) && (rvfi.insn[13:12] != 0) && ((rvfi.insn >> 16 >> 16) == 0);
+	wire [11:0] csr_insn_addr = rvfi.insn[31:20];
+	wire csr_hpmcounter_under_test = (csr_insn_addr == `csr_mindex(`RISCV_FORMAL_CSRC_HPMCOUNTER)
+		|| csr_insn_addr == `csr_mindexh(`RISCV_FORMAL_CSRC_HPMCOUNTER));
+	wire csr_hpmevent_under_test = (csr_insn_addr == `csr_mindex(`RISCV_FORMAL_CSRC_NAME));
+
+	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rmask = `csrget(`RISCV_FORMAL_CSRC_NAME, rmask);
+	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wmask = `csrget(`RISCV_FORMAL_CSRC_NAME, wmask);
+	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_rdata = `csrget(`RISCV_FORMAL_CSRC_NAME, rdata);
+	wire [`RISCV_FORMAL_XLEN-1:0] csr_insn_wdata = `csrget(`RISCV_FORMAL_CSRC_NAME, wdata);
+	wire [`RISCV_FORMAL_XLEN-1:0] hpmcounter_rdata = `csrget(`RISCV_FORMAL_CSRC_HPMCOUNTER, rdata);
+
+	wire csr_write = !rvfi.insn[13] || rvfi.insn[19:15];
+	wire csr_read = rvfi.insn[11:7] != 0;
+	wire csr_write_valid = csr_write && csr_insn_valid;
+	wire csr_read_valid = csr_read && csr_insn_valid;
+	wire [1:0] csr_mode = rvfi.insn[13:12];
+	wire [31:0] csr_rsval = rvfi.insn[14] ? rvfi.insn[19:15] : rvfi.rs1_rdata;
+
+	// Setup for reg testing
+	`rvformal_rand_const_reg [63:0] insn_order;
+	reg [31:0] csr_hpmcounter_shadow = 0;
+	reg csr_hpmevent_written;
+
+	always @(posedge clock) begin
+		if (reset) begin
+			csr_hpmcounter_shadow = 0;
+			csr_hpmevent_written = 0;
+		end else begin
+			// No writes of CSR under test allowed
+			assume (!(csr_write_valid && csr_hpmcounter_under_test));
+			if (csr_hpmevent_written) begin
+				// event CSR should hold the desired event 
+				assume (csr_insn_rdata == `RISCV_FORMAL_CSRC_HPMEVENT);
+				// counter CSR should eventually increase
+				cover (hpmcounter_rdata > csr_hpmcounter_shadow);
+			end
+			if (csr_write_valid && csr_hpmevent_under_test) begin
+				csr_hpmcounter_shadow = hpmcounter_rdata;
+				csr_hpmevent_written = 1;
+			end
+		end
+	end
+endmodule

--- a/cores/nerv/checks.cfg
+++ b/cores/nerv/checks.cfg
@@ -40,6 +40,7 @@ csrc_any   1    5
 csrc_inc   1    5
 csrc_const 1    5
 csrc_upcnt 1    10
+csrc_hpm   1    10
 
 [sort]
 reg_ch0
@@ -50,6 +51,10 @@ csrc_upcnt_(.*)_ch0
 [csrs]
 mcycle          upcnt
 minstret        upcnt
+mhpmcounter5    inc
+mhpmevent5      hpm=1
+mhpmevent9      hpm=2
+mhpmevent3      hpm=3
 
 [custom_csrs]
 fc0     m       custom_ro       const="32'h dead_beef"
@@ -77,27 +82,3 @@ f11     m       w
 [cover]
 always @* if (!reset) cover (channel[0].cnt_insns == 2);
 always @* if (!reset) cover (rvfi_csr_mstatus_rdata[3] != 0 && rvfi_valid == 1);
-# Cover check for hpm event of 3
-wire csr_insn_valid = rvfi_valid && (rvfi_insn[6:0] == 7'b 1110011) && (rvfi_insn[13:12] != 0) && ((rvfi_insn >> 16 >> 16) == 0);
-wire [11:0] csr_insn_addr = rvfi_insn[31:20];
-wire csr_hpmcounter_under_test = csr_insn_addr == 12'h B03 || csr_insn_addr == 12'h B83;
-wire csr_hpmevent_under_test = csr_insn_addr == 12'h 323;
-wire csr_write_valid = (!rvfi_insn[13] || rvfi_insn[19:15]) && csr_insn_valid;
-reg [31:0] csr_hpmcounter_shadow = 0;
-reg csr_hpmevent_written;
-always @(posedge clock) begin
-    if (reset) begin
-        csr_hpmcounter_shadow = 0;
-        csr_hpmevent_written = 0;
-    end else begin
-        // No writes of CSR under test allowed
-        assume (!(csr_write_valid && csr_hpmcounter_under_test));
-        cover(csr_hpmevent_written && (rvfi_csr_mhpmcounter3_rdata > csr_hpmcounter_shadow));
-        if (csr_write_valid && csr_hpmevent_under_test) begin
-            assume (rvfi_csr_mhpmevent3_wdata == 3);
-            csr_hpmcounter_shadow = rvfi_csr_mhpmcounter3_rdata;
-            csr_hpmevent_written = 1;
-        end
-    end
-end
-

--- a/docs/procedure.md
+++ b/docs/procedure.md
@@ -301,13 +301,15 @@ as written.
 #### CSR increments
 
 The `csrc_inc` check tests whether the value in a CSR is always greater than or equal to a previous
-read/write of the csr.  
+read/write of the csr.  By constraining the most significant bit to be 0, this check can verify that
+the value of a CSR can never decrease except by writing to it.  This is particularly useful for
+hardware performance monitors.
 
 #### CSR up-counter
 
-The `csrc_upcnt` check is similar to the CSR increments check but with more constraints and better
-support for hardware performance monitors.  First, no writes of the csr under test are allowed.
-Second, the test value *must* be greater than the previously read value.
+The `csrc_upcnt` check is similar to the CSR increments check but with more constraints.  First, no
+writes of the csr under test are allowed. Second, the test value *must* be greater than the
+previously read value.  Without fairness guarantees this has limited use, but can verify some hpm functions, especially `mcycle` and `minstret`.
 
 #### CSR read-constant
 

--- a/docs/procedure.md
+++ b/docs/procedure.md
@@ -311,6 +311,19 @@ The `csrc_upcnt` check is similar to the CSR increments check but with more cons
 writes of the csr under test are allowed. Second, the test value *must* be greater than the
 previously read value.  Without fairness guarantees this has limited use, but can verify some hpm functions, especially `mcycle` and `minstret`.
 
+#### CSR hpm event cover check
+
+Unlike most of the other checks, `csrc_hpm` is a cover check.  Similarly to the CSR up-counter
+check, the value of a hpm counter CSR is compared with a previously stored value and must increase.
+However, because this is a cover check this tests that the CSR *can* increase, not that it *must*
+increase.  Used in conjunction with a `csrc_inc` test of the corresponding hpm counter CSR, this can
+verify that the hpm is able to increase and unable to decrease.
+
+This check must be performed on a hpm event CSR, with `RISCV_FORMAL_CSRC_NAME mhpmevent#` and
+`RISCV_FORMAL_CSRC_HPMCOUNTER mhpmcounter#`.  The event must be defined by
+`RISCV_FORMAL_CSRC_HPMEVENT <value>`.  Note that both `RISCV_FORMAL_CSR_MHPMCOUNTER#` and
+`RISCV_FORMAL_CSR_MHPMEVENT#` must be defined and the corresponding rvfi signals connected.
+
 #### CSR read-constant
 
 The `csrc_const` check tests whether the value in a CSR is always the same, ignoring any value which
@@ -356,8 +369,10 @@ any other value assignment for the check.  For example, the statement `misa cons
 0aaa_ffff"` masks the `misa` CSR and then checks for a constant value of 0. A mask value is
 currently only supported in the `const`, `zero`, and `any` checks.
 
-`const` is currently the only other test to support value assignment.  If no value is provided, a
+`const` supports value assignment, while `hpm` requires it.  If no value is provided for `const`, a
 value of `rdata_shadow` will be assigned such that any value is accepted provided it is constant.
+In the case of `hpm` the value is assigned to the hpmevent register prior to testing if the
+hpmcounter register is able to increase.
 
 #### `[custom_csrs]`
 


### PR DESCRIPTION
Verifies that a hpmevent csr with specified value will result in corresponding hpmcounter eventually incrementing.
Currently only supports testing 1 hpmevent value per hpm csr.