### PR TITLE
Re-enable serv liveness check 

### DIFF
--- a/cores/serv/checks.cfg
+++ b/cores/serv/checks.cfg
@@ -7,12 +7,15 @@ insn            80
 reg       1     80
 pc_fwd    1     80
 pc_bwd    1     80
-# liveness  1  50 80
+liveness  1  40 150
 unique    1  50 80
 causal    1     80
 
 [defines]
 `define RISCV_FORMAL_ALIGNED_MEM
+
+[defines liveness]
+`define MEMIO_FAIRNESS
 
 [verilog-files]
 @basedir@/cores/@core@/wrapper.sv

--- a/cores/serv/cover.gtkw
+++ b/cores/serv/cover.gtkw
@@ -2,77 +2,52 @@
 [*] GTKWave Analyzer v3.3.89 (w)1999-2018 BSI
 [*] Thu Nov  1 11:25:45 2018
 [*]
-[dumpfile] "/home/claire/Work/riscv-formal/cores/serv/cover/engine_0/trace0.vcd"
-[dumpfile_mtime] "Thu Nov  1 11:24:51 2018"
-[dumpfile_size] 121959
-[savefile] "/home/claire/Work/riscv-formal/cores/serv/cover.gtkw"
 [timestart] 0
 [size] 1394 830
 [pos] -1 -1
 *-5.990967 5 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
-[treeopen] testbench.
-[treeopen] testbench.wrapper.
+[treeopen] rvfi_testbench.
+[treeopen] rvfi_testbench.wrapper.
 [sst_width] 225
 [signals_width] 310
 [sst_expanded] 1
 [sst_vpaned_height] 241
 @24
-testbench.cycle[31:0]
-testbench.wrapper.icnt[31:0]
-@25
-testbench.wrapper.dcnt[31:0]
+rvfi_testbench.cycle[7:0]
 @200
 -
 @28
-testbench.wrapper.clock
-testbench.wrapper.reset
+rvfi_testbench.wrapper.clock
+rvfi_testbench.wrapper.reset
 @200
 -
 -I-MEM
 @28
-testbench.wrapper.o_i_ca_vld
-testbench.wrapper.i_i_ca_rdy
+rvfi_testbench.wrapper.ibus_cyc
+rvfi_testbench.wrapper.ibus_ack
 @22
-testbench.wrapper.o_i_ca_adr[31:0]
-@200
--
-@28
-testbench.wrapper.i_i_rd_vld
-testbench.wrapper.o_i_rd_rdy
-@22
-testbench.wrapper.i_i_rd_dat[31:0]
+rvfi_testbench.wrapper.ibus_adr[31:0]
+rvfi_testbench.wrapper.ibus_rdt[31:0]
 @200
 -
 -D-MEM
 @28
-testbench.wrapper.o_d_ca_vld
-testbench.wrapper.i_d_ca_rdy
-testbench.wrapper.o_d_ca_cmd
+rvfi_testbench.wrapper.dbus_cyc
+rvfi_testbench.wrapper.dbus_ack
+rvfi_testbench.wrapper.dbus_we
 @22
-testbench.wrapper.o_d_ca_adr[31:0]
-@200
--
-@28
-testbench.wrapper.o_d_dm_vld
-testbench.wrapper.i_d_dm_rdy
-@22
-testbench.wrapper.o_d_dm_dat[31:0]
-testbench.wrapper.o_d_dm_msk[3:0]
-@200
--
-@28
-testbench.wrapper.i_d_rd_vld
-testbench.wrapper.o_d_rd_rdy
-@22
-testbench.wrapper.i_d_rd_dat[31:0]
+rvfi_testbench.wrapper.dbus_adr[31:0]
+rvfi_testbench.wrapper.dbus_dat[31:0]
+rvfi_testbench.wrapper.dbus_sel[3:0]
+rvfi_testbench.wrapper.dbus_rdt[31:0]
 @200
 -
 -RVFI
 @28
-testbench.wrapper.rvfi_valid
+rvfi_testbench.wrapper.rvfi_valid
 @22
-testbench.wrapper.rvfi_insn[31:0]
-testbench.wrapper.rvfi_pc_rdata[31:0]
+rvfi_testbench.wrapper.rvfi_insn[31:0]
+rvfi_testbench.wrapper.rvfi_pc_rdata[31:0]
 @200
 -
 -

--- a/cores/serv/wrapper.sv
+++ b/cores/serv/wrapper.sv
@@ -59,8 +59,8 @@ module rvfi_wrapper (
 	end
 
 `ifdef MEMIO_FAIRNESS
-	reg [2:0] timeout_ibus = 0;
-	reg [2:0] timeout_dbus = 0;
+	reg [3:0] timeout_ibus = 0;
+	reg [3:0] timeout_dbus = 0;
 
 	always @(posedge clock) begin
 		timeout_ibus <= 0;
@@ -72,8 +72,8 @@ module rvfi_wrapper (
 		if (dbus_cyc && !dbus_ack)
 			timeout_dbus <= timeout_dbus + 1;
 
-		assume (!timeout_ibus[2]);
-		assume (!timeout_dbus[2]);
+		assume (!timeout_ibus[3]);
+		assume (!timeout_dbus[3]);
 	end
 `endif
 endmodule


### PR DESCRIPTION
Defines fairness flag for liveness test, extending the timeout_*bus length to 4 bits and extending the check depth.