### PR TITLE
vexriscv: correct isa to rv32ic

### DIFF
--- a/cores/VexRiscv/checks.cfg
+++ b/cores/VexRiscv/checks.cfg
@@ -1,6 +1,6 @@
 
 [options]
-isa rv32i
+isa rv32ic
 
 [depth]
 insn            20


### PR DESCRIPTION
The VexRiscv config included in this repo has support for compressed instructions (see [the config](https://github.com/SpinalHDL/VexRiscv/blob/7f2bccbef256b3ad40fb8dc8ba08a266f9c6256b/src/main/scala/vexriscv/demo/FormalSimple.scala#L22)), but was configured as `rv32i`. This caused the instruction failures in #10, as `rv32i` requires branches to 2-byte aligned addresses to trap but `rv32ic` does not (as compressed instructions are 2-byte aligned).

I have only tested the instruction checks to a bound of 15 as I am just running on a laptop, but it would be good for someone to test them to 20 (maybe @jix if you feel like running them for a bit at somepoint). None of the instruction checks (including the new c extension instructions) fail within this bound, although the liveness case mentioned in #10 does still fail.