### PR TITLE
Fix xperm8/xperm4: lookup is scaled by element size

### DIFF
--- a/insns/insn_xperm4.v
+++ b/insns/insn_xperm4.v
@@ -49,7 +49,7 @@ module rvfi_insn_xperm4 (
     result = 0;
     for (i=0; i<`RISCV_FORMAL_XLEN; i=i+4)
     begin
-      result[i+:4] = (rvfi_rs1_rdata >> rvfi_rs2_rdata[i+:4]) & {4{1'b1}};
+      result[i+:4] = (rvfi_rs1_rdata >> {rvfi_rs2_rdata[i+:4], 2'b00}) & {4{1'b1}};
     end
   end
   assign spec_valid = rvfi_valid && !insn_padding && insn_funct7 == 7'b 0010100 && insn_funct3 == 3'b 010 && insn_opcode == 7'b 01100_11;

--- a/insns/insn_xperm8.v
+++ b/insns/insn_xperm8.v
@@ -49,7 +49,7 @@ module rvfi_insn_xperm8 (
     result = 0;
     for (i=0; i<`RISCV_FORMAL_XLEN; i=i+8)
     begin
-      result[i+:8] = (rvfi_rs1_rdata >> rvfi_rs2_rdata[i+:8]) & {8{1'b1}};
+      result[i+:8] = (rvfi_rs1_rdata >> {rvfi_rs2_rdata[i+:8], 3'b000}) & {8{1'b1}};
     end
   end
   assign spec_valid = rvfi_valid && !insn_padding && insn_funct7 == 7'b 0010100 && insn_funct3 == 3'b 100 && insn_opcode == 7'b 01100_11;


### PR DESCRIPTION
The instruction model is shifting the register in units of one bit, but it should actually be in units of 4 or 8 bits depending on element size. See e.g. xperm4 description here in the ISA manual:

<img width="989" height="846" alt="image" src="https://github.com/user-attachments/assets/21cf2050-6ba3-4701-9070-54d1d8d415f9" />
