### PR TITLE
Upgrade CI actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
 
     steps:
       - name: Checkout RiscV-Formal
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install oss-cad-suite
-        uses: YosysHQ/setup-oss-cad-suite@v3
+        uses: YosysHQ/setup-oss-cad-suite@v4
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: "CodeQL"
 
 on:
-  push:
-  pull_request:
   workflow_dispatch:
   schedule:
     - cron: '0 3 * * *'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -13,13 +13,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v5
 
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@v4
       with:
         languages: python
         queries: security-extended,security-and-quality
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@v4


### PR DESCRIPTION
Upgrades CI actions to remove warnings.
NOTE: Private runners still do not support this new version