### PR TITLE
Add riscv-formal support for Ridecore

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "cores/ridecore/ridecore-src"]
+	path = cores/ridecore/ridecore-src
+	url = https://github.com/gipsyh/ridecore-rvfi.git

--- a/cores/ridecore/.gitignore
+++ b/cores/ridecore/.gitignore
@@ -1,2 +1,1 @@
-ridecore-src/
 checks/

--- a/cores/ridecore/.gitignore
+++ b/cores/ridecore/.gitignore
@@ -1,0 +1,2 @@
+ridecore-src/
+checks/

--- a/cores/ridecore/README.md
+++ b/cores/ridecore/README.md
@@ -1,0 +1,16 @@
+# RISCV-Formal for RIDECORE
+
+First install Yosys, SymbiYosys, and the solvers. See
+[here](http://symbiyosys.readthedocs.io/en/latest/quickstart.html#installing)
+for instructions. Then build the version of Ridecore with RVFI support and
+generate the formal checks:
+
+```
+bash generate.sh
+```
+
+Then run the formal checks:
+
+```
+make -C checks
+```

--- a/cores/ridecore/README.md
+++ b/cores/ridecore/README.md
@@ -6,7 +6,8 @@ for instructions. Then build the version of Ridecore with RVFI support and
 generate the formal checks:
 
 ```
-bash generate.sh
+git submodule update --init
+python3 ../../checks/genchecks.py
 ```
 
 Then run the formal checks:

--- a/cores/ridecore/checks.cfg
+++ b/cores/ridecore/checks.cfg
@@ -1,0 +1,58 @@
+[options]
+isa rv32im
+nret 2
+solver bitwuzla
+
+[depth]
+insn            8
+reg       1     8
+pc_fwd    1     8
+pc_bwd    1     8
+unique    1     4   8
+causal    1     8
+
+[filter-checks]
+- insn_(lb|lh|lbu|lhu|sb|sh|jalr|div|divu|rem|remu)_ch[01]
+- ill_ch[01]
+
+[script-defines]
+verilog_defaults -add -I@basedir@/cores/@core@/ridecore-src/src/fpga
+
+[defines]
+`define DEBUGNETS
+
+[verilog-files]
+@basedir@/cores/@core@/wrapper.sv
+@basedir@/cores/@core@/ridecore-src/src/fpga/ram_sync_nolatch.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/prioenc.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/alloc_issue_ino.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/search_be.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/oldest_finder.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/srcsel.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/alu.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/multiplier.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/decoder.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/imm_gen.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/brimm_gen.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/src_manager.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/srcopr_manager.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/rs_reqgen.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/tag_generator.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/mpft.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/btb.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/gshare.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/arf.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/rrf.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/rrf_freelistmanager.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/rs_alu.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/rs_ldst.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/rs_branch.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/rs_mul.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/storebuf.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/exunit_alu.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/exunit_ldst.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/exunit_mul.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/exunit_branch.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/pipeline_if.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/reorderbuf.v
+@basedir@/cores/@core@/ridecore-src/src/fpga/pipeline.v

--- a/cores/ridecore/generate.sh
+++ b/cores/ridecore/generate.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-set -ex
-rm -rf ridecore-src checks
-git clone https://github.com/gipsyh/ridecore-rvfi.git ridecore-src
-python3 ../../checks/genchecks.py

--- a/cores/ridecore/generate.sh
+++ b/cores/ridecore/generate.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -ex
+rm -rf ridecore-src checks
+git clone https://github.com/gipsyh/ridecore-rvfi.git ridecore-src
+python3 ../../checks/genchecks.py

--- a/cores/ridecore/wrapper.sv
+++ b/cores/ridecore/wrapper.sv
@@ -1,0 +1,56 @@
+`include "constants.vh"
+`include "rv32_opcodes.vh"
+
+module rvfi_wrapper (
+	input clock,
+	input reset,
+	`RVFI_OUTPUTS
+);
+	(* keep *) `rvformal_rand_reg [4*`INSN_LEN-1:0] idata;
+	(* keep *) `rvformal_rand_reg [`DATA_LEN-1:0] dmem_data;
+
+	(* keep *) wire [`ADDR_LEN-1:0] pc;
+	(* keep *) wire [`DATA_LEN-1:0] dmem_wdata;
+	(* keep *) wire [`ADDR_LEN-1:0] dmem_addr;
+	(* keep *) wire dmem_we;
+
+	// The core currently does not model instruction-address-misaligned traps
+	// in RVFI (`rvfi_trap` is tied low). Constrain random fetch data so taken
+	// BRANCH/JAL targets stay 4-byte aligned for the RV32I/M environment.
+	wire [`INSN_LEN-1:0] idata0 = idata[31:0];
+	wire [`INSN_LEN-1:0] idata1 = idata[63:32];
+	wire [`INSN_LEN-1:0] idata2 = idata[95:64];
+	wire [`INSN_LEN-1:0] idata3 = idata[127:96];
+
+	wire idata0_aligned_target =
+		(idata0[6:0] != `RV32_BRANCH || !idata0[8]) &&
+		(idata0[6:0] != `RV32_JAL || !idata0[21]);
+	wire idata1_aligned_target =
+		(idata1[6:0] != `RV32_BRANCH || !idata1[8]) &&
+		(idata1[6:0] != `RV32_JAL || !idata1[21]);
+	wire idata2_aligned_target =
+		(idata2[6:0] != `RV32_BRANCH || !idata2[8]) &&
+		(idata2[6:0] != `RV32_JAL || !idata2[21]);
+	wire idata3_aligned_target =
+		(idata3[6:0] != `RV32_BRANCH || !idata3[8]) &&
+		(idata3[6:0] != `RV32_JAL || !idata3[21]);
+
+	always @* begin
+		assume(idata0_aligned_target);
+		assume(idata1_aligned_target);
+		assume(idata2_aligned_target);
+		assume(idata3_aligned_target);
+	end
+
+	pipeline uut (
+		.clk(clock),
+		.reset(reset),
+		.pc(pc),
+		.idata(idata),
+		.dmem_wdata(dmem_wdata),
+		.dmem_we(dmem_we),
+		.dmem_addr(dmem_addr),
+		.dmem_data(dmem_data),
+		`RVFI_CONN
+	);
+endmodule

--- a/cores/ridecore/wrapper.sv
+++ b/cores/ridecore/wrapper.sv
@@ -1,3 +1,4 @@
+`include "defines.sv"
 `include "constants.vh"
 `include "rv32_opcodes.vh"
 


### PR DESCRIPTION
Add riscv-formal support for Ridecore.

Add RVFI for RIDECORE in https://github.com/gipsyh/ridecore-rvfi.git

Add wrapper and config in cores/ridecore

Assisted by Codex ChatGPT 5.5 Extra High

## Testing
```sh
bash generate.sh
make -C checks
```
```
SBY 10:26:34 [causal_ch0] engine_0: smtbmc bitwuzla
SBY 10:26:34 [causal_ch0] base: starting process "cd causal_ch0/src; yosys -ql ../model/design.log ../model/design.ys"
SBY 10:26:39 [causal_ch0] base: finished (returncode=0)
SBY 10:26:39 [causal_ch0] prep: starting process "cd causal_ch0/model; yosys -ql design_prep.log design_prep.ys"
SBY 10:26:41 [causal_ch0] prep: finished (returncode=0)
SBY 10:26:41 [causal_ch0] smt2: starting process "cd causal_ch0/model; yosys -ql design_smt2.log design_smt2.ys"
SBY 10:26:41 [causal_ch0] smt2: finished (returncode=0)
SBY 10:26:41 [causal_ch0] engine_0: starting process "cd causal_ch0; yosys-smtbmc -s bitwuzla --presat --unroll --noprogress -t 8:9  --append 0 --dump-vcd engine_0/trace.vcd --dump-yw engine_0/trace.yw --dump-vlogtb engine_0/trace_tb.v --dump-smtc engine_0/trace.smtc model/design_smt2.smt2"
SBY 10:26:41 [causal_ch0] engine_0: ##   0:00:00  Solver: bitwuzla
SBY 10:26:42 [causal_ch0] engine_0: ##   0:00:00  Skipping step 0..
SBY 10:26:42 [causal_ch0] engine_0: ##   0:00:00  Skipping step 1..
SBY 10:26:43 [causal_ch0] engine_0: ##   0:00:01  Skipping step 2..
SBY 10:26:43 [causal_ch0] engine_0: ##   0:00:01  Skipping step 3..
SBY 10:26:43 [causal_ch0] engine_0: ##   0:00:01  Skipping step 4..
SBY 10:26:43 [causal_ch0] engine_0: ##   0:00:02  Skipping step 5..
SBY 10:26:44 [causal_ch0] engine_0: ##   0:00:02  Skipping step 6..
SBY 10:26:44 [causal_ch0] engine_0: ##   0:00:02  Skipping step 7..
SBY 10:26:44 [causal_ch0] engine_0: ##   0:00:02  Checking assumptions in step 8..
SBY 10:26:47 [causal_ch0] engine_0: ##   0:00:05  Checking assertions in step 8..
SBY 10:26:48 [causal_ch0] engine_0: ##   0:00:06  Status: passed
SBY 10:26:48 [causal_ch0] engine_0: finished (returncode=0)
SBY 10:26:48 [causal_ch0] engine_0: Status returned by engine: pass
SBY 10:26:48 [causal_ch0] summary: Elapsed clock time [H:MM:SS (secs)]: 0:00:13 (13)
SBY 10:26:48 [causal_ch0] summary: Elapsed process time [H:MM:SS (secs)]: 0:00:15 (15)
SBY 10:26:48 [causal_ch0] summary: engine_0 (smtbmc bitwuzla) returned pass
SBY 10:26:48 [causal_ch0] summary: engine_0 did not produce any traces
SBY 10:26:48 [causal_ch0] DONE (PASS, rc=0)
```