### PR TITLE
Replace unrolled for-loops with symbolic free variables in assertion checks.

### DIFF
--- a/checks/rvfi_bus_dmem_fault_check.sv
+++ b/checks/rvfi_bus_dmem_fault_check.sv
@@ -45,6 +45,11 @@ module rvfi_bus_dmem_fault_check (
 `endif
 
 	integer channel_idx, i, j;
+	// Anyseq acts as a universal quantifier for assert: the solver must
+	// find a counterexample for SOME value of k, which is equivalent to
+	// the unrolled for loop. Safe because RISCV_FORMAL_XLEN is 32 or 64,
+	// so every value of k[$clog2(XLEN/8)-1:0] is a valid byte index < XLEN/8.
+	`rvformal_rand_reg [$clog2(`RISCV_FORMAL_XLEN/8)-1:0] k;
 
 	always @(posedge clock) begin
 		if (!reset) begin
@@ -85,24 +90,24 @@ module rvfi_bus_dmem_fault_check (
 `endif
 
 				if (rvfi_valid[channel_idx] && mem_addr == dmem_addr && `rvformal_addr_valid(dmem_addr)) begin
-					for (i = 0; i < `RISCV_FORMAL_XLEN/8; i = i+1) begin
-						if (check && channel_idx == `RISCV_FORMAL_CHANNEL_IDX) begin
+					// for (i = 0; i < `RISCV_FORMAL_XLEN/8; i = i+1) begin
+					if (check && channel_idx == `RISCV_FORMAL_CHANNEL_IDX) begin
 `ifndef RISCV_FORMAL_MEM_FAULT
-							cover (1);
+						cover (1);
 `endif
 
-							assert (!mem_rmask[i]);
-							assert (!mem_wmask[i]);
+						assert (!mem_rmask[k]);
+						assert (!mem_wmask[k]);
 
 `ifdef RISCV_FORMAL_MEM_FAULT
-							cover (mem_fault_rmask[i]);
-							cover (mem_fault_wmask[i]);
-							if (mem_fault_rmask[i] || mem_fault_wmask[i]) begin
-								assert (rvfi_mem_fault[channel_idx]);
-							end
-`endif
+						cover (mem_fault_rmask[k]);
+						cover (mem_fault_wmask[k]);
+						if (mem_fault_rmask[k] || mem_fault_wmask[k]) begin
+							assert (rvfi_mem_fault[channel_idx]);
 						end
+`endif
 					end
+					// end
 				end
 			end
 		end

--- a/checks/rvfi_insn_check.sv
+++ b/checks/rvfi_insn_check.sv
@@ -128,7 +128,11 @@ module rvfi_insn_check (
 				(spec_mem_rmask && !mem_pma_r) || (spec_mem_wmask && !mem_pma_w) ||
 				((spec_mem_rmask || spec_mem_wmask) && !`rvformal_addr_valid(spec_mem_addr));
 
-		integer i;
+		// Anyseq acts as a universal quantifier for assert: the solver must
+		// find a counterexample for SOME value of i, which is equivalent to
+		// the unrolled for loop. Safe because RISCV_FORMAL_XLEN is 32 or 64,
+		// so every value of i[$clog2(XLEN/8)-1:0] is a valid byte index < XLEN/8.
+		`rvformal_rand_reg [$clog2(`RISCV_FORMAL_XLEN/8)-1:0] i;
 
 		always @* begin
 			if (!reset) begin
@@ -181,18 +185,18 @@ module rvfi_insn_check (
 							assert(`rvformal_addr_eq(spec_mem_addr, mem_addr));
 						end
 
-						for (i = 0; i < `RISCV_FORMAL_XLEN/8; i = i+1) begin
-							if (spec_mem_wmask[i]) begin
-								assert(mem_wmask[i]);
-								assert(spec_mem_wdata[i*8 +: 8] == mem_wdata[i*8 +: 8]);
-							end else if (mem_wmask[i]) begin
-								assert(mem_rmask[i]);
-								assert(mem_rdata[i*8 +: 8] == mem_wdata[i*8 +: 8]);
-							end
-							if (spec_mem_rmask[i]) begin
-								assert(mem_rmask[i]);
-							end
+						// for (i = 0; i < `RISCV_FORMAL_XLEN/8; i = i+1) begin
+						if (spec_mem_wmask[i]) begin
+							assert(mem_wmask[i]);
+							assert(spec_mem_wdata[i*8 +: 8] == mem_wdata[i*8 +: 8]);
+						end else if (mem_wmask[i]) begin
+							assert(mem_rmask[i]);
+							assert(mem_rdata[i*8 +: 8] == mem_wdata[i*8 +: 8]);
 						end
+						if (spec_mem_rmask[i]) begin
+							assert(mem_rmask[i]);
+						end
+						// end
 					end
 
 					assert(spec_trap == trap);


### PR DESCRIPTION
## Summary

- Replace for-loop iterations over byte channels with `rvformal_rand_reg` (anyseq) symbolic indices in `rvfi_insn_check.sv` and `rvfi_bus_dmem_fault_check.sv`.
- The formal solver now reasons symbolically over all valid index values instead of proving N separate unfolded assertion instances, which can reduce memory usage and state space for the solver.

## What changed

**`checks/rvfi_insn_check.sv`** — Loop variable `integer i` replaced with `rvformal_rand_reg [$clog2(RISCV_FORMAL_XLEN/8)-1:0] i`, and the `for (i = 0; i < XLEN/8; i=i+1)` loop over byte-channel assertions removed. The loop body now uses symbolic `i` directly.

**`checks/rvfi_bus_dmem_fault_check.sv`** — Added `rvformal_rand_reg [$clog2(RISCV_FORMAL_XLEN/8)-1:0] k`, and the `for (i = 0; i < XLEN/8; i=i+1)` loop over byte-channel asserts/covers removed. The loop body now uses symbolic `k` directly.

## Why this works

`rvformal_rand_reg` elaborates to an anyseq free variable. For **assertions**, anyseq acts as a universal quantifier: the solver must satisfy the assert for every possible value of the free variable, so finding a counterexample for any value is sufficient to falsify the property — logically equivalent to the unrolled loop, but represented as a single symbolic proof obligation rather than N independent ones.

The variable width is `$clog2(XLEN/8)` bits, which covers exactly the valid byte-index range `[0, XLEN/8)`. This is safe because `RISCV_FORMAL_XLEN` is always 32 or 64, so every representable value of the index is a valid byte offset — no out-of-range values exist and no additional `assume` on the range is needed.

## Test

- consistent with nerv core checks.
