### PR TITLE
Trivial Documentation Fixes

### DIFF
--- a/docs/source/config.rst
+++ b/docs/source/config.rst
@@ -5,7 +5,7 @@ Configuration macros
 ====================
 
 The riscv-formal insn models and checkers are configured using a few
-Verilog pre-processor macros. They must be defined bofore reading any
+Verilog pre-processor macros. They must be defined before reading any
 riscv-formal verilog files. The first riscv-formal verilog file read
 after defining the macros must be ``rvfi_macros.vh``.
 
@@ -48,7 +48,7 @@ RISCV_FORMAL_ALIGNED_MEM
 
 Cores that only have hardware support for word-aligned memory access may
 choose to retire memory load/store operations for smaller units
-(half-words, bytes) word aligned with the appropiate ``rmask/wmask``
+(half-words, bytes) word aligned with the appropriate ``rmask/wmask``
 values to select the correct bytes. In this case the
 ``RISCV_FORMAL_ALIGNED_MEM`` macro must be defined.
 
@@ -239,7 +239,7 @@ RVFI_WIRES, RVFI_OUTPUTS, RVFI_INPUTS, RVFI_CONN
 
 Macros to declare wires, output ports, or input ports for all ``rvfi_*``
 signals. The last macro is for creating the proper connections on module
-instances. This macros can be useful for routing the ``rvfi_*`` signals
+instances. These macros can be useful for routing the ``rvfi_*`` signals
 through the design hierarchy.
 
 rvformal_rand_reg and rvformal_rand_const_reg

--- a/docs/source/csrs.rst
+++ b/docs/source/csrs.rst
@@ -6,11 +6,11 @@ values observable via the ISA. But there are a few minor differences
 that are outlined here.
 
 Most importantly, for RV64 processors in RV32 mode, the values output
-via RVFI are still following RV64 CSR encondings, including some of the
+via RVFI are still following RV64 CSR encodings, including some of the
 information that is not available through the RV32 ISA, such as SXL and
 UXL in ``mstatus``.
 
-Counters are always output as singe 64-bit wide CSRs even on RV32
+Counters are always output as single 64-bit wide CSRs even on RV32
 targets.
 
 M-mode CSRs
@@ -69,7 +69,7 @@ mepc
 ^^^^
 
 The version of ``mepc`` observable through the ISA masks ``mepc[1]`` on
-CSR reads when the processor is in a mode that does not supprt 16-bit
+CSR reads when the processor is in a mode that does not support 16-bit
 instruction alignment. However, writes to that bit shall still modify
 the underlying architectural state.
 

--- a/docs/source/examplebugs.rst
+++ b/docs/source/examplebugs.rst
@@ -36,7 +36,7 @@ JALR clears LSB after addition
 
 The JALR instruction adds an immediate to its source register, clears
 the LSB of the sum, and then jumps to the resulting address. (It also
-stores the address of the next instruction in the desitination
+stores the address of the next instruction in the destination
 register.)
 
 The code C compilers generate usually (always?) have the LSB of the sum

--- a/docs/source/procedure.rst
+++ b/docs/source/procedure.rst
@@ -1,7 +1,7 @@
 Verification procedure
 ======================
 
-The following formal test are performed to verify ISA compliance of
+The following formal tests are performed to verify ISA compliance of
 RISC-V processors with ``riscv-formal``. Depending on aspects like the
 strength of safety properties present in the core, the overall
 complexity of the core, and the verification requirements for the given
@@ -317,7 +317,7 @@ are instruction checks (one per RVFI channel and RISC-V instruction
 supported by the core).
 
 Instruction checks test if the instruction (``rvfi_insn``) matches the
-state transistion described by the other RVFI signals.
+state transition described by the other RVFI signals.
 
 PC checks
 ~~~~~~~~~
@@ -349,7 +349,7 @@ Register checks
 
 This checks if writes to and reads from the register file are consistent
 with each other, i.e. if the value written to a register matches the
-value read from the register file by a later instructions.
+value read from the register file by a later instruction.
 
 This check assumes that the last instruction at the end of the bounded
 model check, reads a register. It then checks that the value read is
@@ -381,7 +381,7 @@ if the instruction stream is causal with respect to i/o memory, where
 every i/o memory access is assumed to depend on all earlier i/o memory
 accesses.
 
-Which areas of the adress space are considered to be i/o memory can be
+Which areas of the address space are considered to be i/o memory can be
 configured using the ``RISCV_FORMAL_IOADDR(addr)`` macro.
 
 .. _depth-section-2:
@@ -402,7 +402,7 @@ the bounded model check. It then checks that the next instruction
 (``rvfi_order+1``) is also retired at some point during the span of the
 bounded model check.
 
-It might be neccessary to add some bounded fairness constraints to the
+It might be necessary to add some bounded fairness constraints to the
 design for this check to succeed.
 
 .. _depth-section-3:
@@ -430,7 +430,7 @@ is the trigger depth; and third is the execution depth.
 Faults
 ~~~~~~
 
-This check makes sure that dynamically occuring memory faults are
+This check makes sure that dynamically occurring memory faults are
 handled. It requires defining ``RISCV_FORMAL_MEM_FAULT`` and the
 ``rvfi_mem_fault``, ``rvfi_mem_fault_rmask`` and
 ``rvfi_mem_fault_wmask`` signals. When the ``mcause`` CSR is exposed via
@@ -490,7 +490,7 @@ unharmed.
 When the granularity of access faults as observed from the core is
 coarser than the width of the bus, ``RISCV_FORMAL_FAULT_WIDTH`` needs to
 be defined and set to the corresponding width in bytes. E.g. for a setup
-where a single word fault the monitored bus means that from the
+where a single word fault on the monitored bus means that from the
 perspective of the core, any access of the corresponding cache line will
 fault, you would define ``RISCV_FORMAL_FAULT_WIDTH`` to be the width of
 a cache line in bytes.
@@ -637,7 +637,7 @@ These checks perform multiple reads/writes and compare the values on
 ``check`` cycle.
 
 In each case, ``RISCV_FORMAL_CSRC_NAME <csrname>`` must be defined for
-the CSR under test, along with the corresponsing
+the CSR under test, along with the corresponding
 ``csr_{m,s,u}index_<csrname> <csraddr>``.
 
 CSR write-any
@@ -724,7 +724,7 @@ be run.
 
 The ``csrs`` config section lists all standard CSRs which can be tested.
 By default, all CSRs will be run through the CSR instruction check
-(``csrw``). Consistency checks can be defined as a space seperated list
+(``csrw``). Consistency checks can be defined as a space separated list
 after the csr name. For checks which expect a value, using quotation
 marks will allow for verbatim values.
 
@@ -783,7 +783,7 @@ separated values are expected; the first provides the address in
 hexadecimal, the second is the privilege modes to test, and the third
 indicates whether to test reads and writes or just writes.
 
-e.g. \ ``fff msu rw`` defines a test at address oxFFF for machine,
+e.g. \ ``fff msu rw`` defines a test at address 0xFFF for machine,
 supervisor, and user modes which should cause an illegal access
 exception on both reads and writes.
 
@@ -805,7 +805,7 @@ just the reserved bits.
 
 At present the only supported value for ``csr_spec`` is ``1.12``,
 corresponding to version 1.12 of the Machine ISA, as defined in the
-20211203 Priveleged Architecture document.
+20211203 Privileged Architecture document.
 
 Other checks
 ------------

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -24,7 +24,7 @@ For additional python requirements:
    python3 -m pip install Verilog_VCD
 
 Some of those tools are packaged for some of the major Linux
-distribution, but those packages are sometimes a few years old and do
+distributions, but those packages are sometimes a few years old and do
 not work with riscv-formal. Follow the descriptions linked above and
 install from the latest sources instead.
 

--- a/docs/source/rvfi.rst
+++ b/docs/source/rvfi.rst
@@ -85,7 +85,7 @@ Integer register read/write
    output [NRET * XLEN - 1 : 0] rvfi_rs2_rdata
 
 ``rvfi_rs1_addr`` and ``rvfi_rs2_addr`` are the decoded ``rs1`` and
-``rs1`` register addresses for the retired instruction. For an
+``rs2`` register addresses for the retired instruction. For an
 instruction that reads no ``rs1``/``rs2`` register, this output can have
 an arbitrary value. However, if this output is nonzero then
 ``rvfi_rs1_rdata`` must carry the value stored in that register in the
@@ -309,7 +309,7 @@ width of the observed bus is independent of ``XLEN`` and is specified
 using ``BUSLEN``. If different channels observe busses of a different
 width, ``BUSLEN`` should be set to the maximum width in use.
 
-RVFI_BUS adds the following ouptuts:
+RVFI_BUS adds the following outputs:
 
 .. code-block:: systemverilog
 
@@ -345,7 +345,7 @@ and written data and are only valid for the bytes corresponding to the
 respective bits in ``rvfi_bus_rmask`` and ``rvfi_bus_wmask``.
 
 All accesses observed using RVFI_BUS are assumed to be in order,
-including acceses in the same cycle which are ordered by increasing
+including accesses in the same cycle which are ordered by increasing
 RVFI_BUS channel index. This may be relaxed by future extensions.
 
 RVFI_BUS observers for standard interfaces
@@ -540,7 +540,7 @@ instructions:
 
 When ``rvfi_skip`` is high the core may output arbitrary data on the
 ``*_rdata`` and ``*_wdata`` ports (excluding ``rvfi_pc_rdata`` and
-``rvfi_pc_wdata``). The register values written by such intrustions may
+``rvfi_pc_wdata``). The register values written by such instructions may
 only be observed by other skipped instructions. An additional formal
 proof must be added to check this property.
 

--- a/docs/source/rvfi.rst
+++ b/docs/source/rvfi.rst
@@ -368,7 +368,7 @@ RVFI TODOs and requests for comments
 ------------------------------------
 
 The following section contains notes on future extensions to RVFI. They
-will come part of the spec as soon as there is at least one core that
+will become part of the spec as soon as there is at least one core that
 implements the feature, and a matching formal check that utilises the
 feature. In many cases the additional ports will only be used (and
 expected from the core) when additional to-be-defined ``RISCV_FORMAL_*``
@@ -496,7 +496,7 @@ existing ``rvfi_mem_*`` interface by asserting bits in both
 There is also no extension to the RVFI port necessary to accommodate the
 ``LR``, ``SC``, ``FENCE`` and ``FENCE.I`` instructions.
 
-Verification of this instructions for a single-core systems can be done
+Verification of these instructions for single-core systems can be done
 using the RVFI port only. A strategy must be defined to verify their
 correct behavior in multicore systems.
 

--- a/docs/source/rvfi.rst
+++ b/docs/source/rvfi.rst
@@ -285,9 +285,9 @@ the bus.
 
 To run these checks, the relevant busses of the core should be connected
 to an abstraction that implements the required bus signalling but
-provides unconstrai (This may be relaxed with an extensions )ned
-responses to the core. The accesses on the bus are then observed and
-constrained by these checks via the RVFI_BUS outputs.
+provides unconstrained responses to the core. The accesses on the bus
+are then observed and constrained by these checks via the RVFI_BUS
+outputs.
 
 Note: When implementing such an abstraction it should output the access
 using RVFI_BUS as soon as the access first appears on the bus, even when


### PR DESCRIPTION
This PR is entirely spelling and grammar fixes for the documentation, plus one change removing a parenthetical that appears to have been mistakenly inserted.